### PR TITLE
do-builds.yml: Add .desktop files to ignore list

### DIFF
--- a/.github/workflows/do-builds.yml
+++ b/.github/workflows/do-builds.yml
@@ -45,7 +45,7 @@ jobs:
       dependencies: ${{ inputs.dependencies }}
 
       codespell: ${{ matrix.codespell }}
-      codespell_ignore_files_list: ChangeLog,*.po,*.svg,LINGUAS,${{ inputs.codespell_ignore_files_list }}
+      codespell_ignore_files_list: ChangeLog,*.desktop,*.po,*.svg,LINGUAS,${{ inputs.codespell_ignore_files_list }}
       codespell_ignore_words_list: gir,${{ inputs.codespell_ignore_words_list }}
 
 


### PR DESCRIPTION
The translations in .desktop files register many false positives and the files themselves are generated from strings elsewhere that will be checked by codespell, meaning that they can be excluded without any impact.

In tandem with linuxmint/cinnamon-control-center#333