### PR TITLE
feat!: update and pin org-wide actions

### DIFF
--- a/.github/workflows/build-on-image.yml
+++ b/.github/workflows/build-on-image.yml
@@ -57,26 +57,22 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ inputs.image }}
-      # Disable seccomp until a container manager in GitHub recognizes
-      # clone3() syscall,
-      # <https://github.com/actions/virtual-environments/issues/3812>.
-      options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout Pull Request
         if: ${{ github.event_name == 'pull_request'}}
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout branch ${{ inputs.commit_id }}
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.commit_id }}
 
       - name: Run Codespell
         if: ${{ inputs.codespell }}
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
         with:
           # only show the typo detected but don't make workflow to fail
           only_warn: 1
@@ -103,7 +99,7 @@ jobs:
 
       - name: Setup SSH upon failure
         if: ${{ failure() && inputs.debug_enabled}}
-        uses: mxschmitt/action-tmate@v3
+        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3.23
         with:
           limit-access-to-actor: true
 
@@ -119,7 +115,7 @@ jobs:
 
       - name: Upload build artifacts
         if: ${{ inputs.upload_artifacts }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: packages-${{ inputs.mint_version }}
           path: |
@@ -129,7 +125,7 @@ jobs:
 
       - name: Bundle packages
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-        uses: TheDoctor0/zip-release@0.7.6
+        uses: TheDoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 # 0.7.6
         with:
           type: 'tar'
           filename: 'packages.tar.gz'
@@ -140,7 +136,7 @@ jobs:
 
       - name: Install gh cli
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-        uses: sersoft-gmbh/setup-gh-cli-action@v3
+        uses: sersoft-gmbh/setup-gh-cli-action@3cb41a4434ca35de4d1c16e00dc7e16d38409494 # v3.0.0
         with:
           version: stable
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -159,7 +155,7 @@ jobs:
 
       - name: Create release
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-        uses: ncipollo/release-action@v1.20.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           artifacts: "output/packages.tar.gz,output/*.changes"

--- a/.github/workflows/pattern-checker.yml
+++ b/.github/workflows/pattern-checker.yml
@@ -24,10 +24,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout calling repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Checkout github-actions repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   repository: linuxmint/github-actions
                   path: _github-actions

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -26,7 +26,7 @@ jobs:
       issues: write
       actions: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           days-before-stale: ${{ inputs.days-before-stale }}
           days-before-close: ${{ inputs.days-before-close }}

--- a/install-deps/action.yml
+++ b/install-deps/action.yml
@@ -3,9 +3,9 @@ description: 'Install dependencies from other repos'
 
 inputs:
   mint_version:
-    description: 'The Mint version pull from (mint21, lmde5)'
+    description: 'The Mint version to pull from'
     required: true
-    default: mint21
+    default: mint22
   dependencies:
     description: 'A comma separated list of owner/repo dependencies to pull the latest build for (such as "linuxmint/xapp, linuxmint/cinnamon-desktop, linuxmint/cinnamon-menus")'
     required: false


### PR DESCRIPTION
# What
Update and pin org-wide actions.
Remove not needed seccomp workaround. Reference: https://github.com/ppisar/libmodulemd/commit/6f39c11dca9aa8204f722eba08f26faf16415310
For mint_version now use `mint22` as fallback.

# Why
Security. As these workflows are referenced in other repositories.

# Context
https://github.com/linuxmint/cinnamon/pull/13666#issue-4131681388

Although I updated versions of previously used actions,  I would not even try to review the source code of all the actions.
Tests welcome. No slop used.